### PR TITLE
Various fixes for typos, conventions, nomenclature & corrections

### DIFF
--- a/lessons/misc-r/full-R-bootcamp/R-basics/01-basics-of-R.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/01-basics-of-R.Rmd
@@ -63,9 +63,11 @@ Use `#` signs to comment. Comment liberally in your R scripts. Anything to the r
 * `install.packages("package-name")` will download a package from one of the CRAN mirrors assuming that a binary is available for your operating system. If you have not set a preferred CRAN mirror in your `options()`, then a menu will pop up asking you to choose a location.
 
 * Use `old.packages()` to list all your locally installed packages that are now out of date. 
-`update.packages()` - with package name will update a single package. Otherwise it will update all interactively. This can take a while if you haven't done it recently. To update everything without any user intervention, use the `ask = FALSE` argument.  
+`update.packages()` - will update all packages in the known libraries interactively. This can take a while if you haven't done it recently. To update everything without any user intervention, use the `ask = FALSE` argument.  
 
-`update.packages(ask = FALSE)`
+```{R, eval = FALSE}
+update.packages(ask = FALSE)
+```
 
 
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/02-data-structures.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/02-data-structures.Rmd
@@ -419,7 +419,7 @@ Lists can also have names.
 
 ```{r, eval = TRUE}
 x <- as.list(1:10)
-names(x) <- letters[seq(x)]
+names(x) <- letters[seq(along = x)]
 x
 ```
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/02-data-structures.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/02-data-structures.Rmd
@@ -1,5 +1,5 @@
 
-# Undestanding basic data types in R
+# Understanding basic data types in R
 
 * To make the best of the R language, you'll need a strong understanding of the basic data types and data structures and how to operate on those.
 
@@ -44,9 +44,9 @@ z <- c(1L, 2L, 3L)
 typeof(z)
 ```
 
-R also has many data structures. These include
+R has many data structures. These include
 
-* vector
+* atomic vector
 * list
 * matrix
 * data frame
@@ -55,27 +55,26 @@ R also has many data structures. These include
 
 
 ### Vectors
-A vector is the most common and basic data structure in `R` and is pretty much the workhorse of R. Vectors can be of two types:
+A vector is the most common and basic data structure in `R` and is pretty much the workhorse of R. Technically, vectors can be one of two types:
 
 * atomic vectors
 * lists
 
-**Atomic Vectors**
-A vector can be a vector of `characters`, `logical`, `integers`or `numeric`.
+although the term "vector" most commonly refers to the atomic type not lists.
 
-Create an empty vector with `vector()` (By default the mode is `logical`. You can be more explicit as shown in the examples below.)
+**Atomic Vectors**
+A vector can be a vector of elements that are most commonly `character`, `logical`, `integer` or `numeric`.
+
+You can create an empty vector with `vector()` (By default the mode is `logical`. You can be more explicit as shown in the examples below.) It is more common to use direct constructors such as `character()`, `numeric()` etc.
 
 ```{r, eval = TRUE}
 x <- vector()
-# with a pre-defined length
-x <- vector(length = 10)
 # with a length and type
 vector("character", length = 10)
-vector("numeric", length = 10)
-vector("integer", length = 10)
-vector("logical", length = 10)
+character(5) ## character vector of length 5
+numeric(5)
+logical(5)
 ```
-The general pattern is `vector(mode of object, length)`.  You can also create vectors by concactenating items using the `c()` function.
 
 Various examples:
 
@@ -84,7 +83,7 @@ x <- c(1, 2, 3)
 x
 length(x)
 ```
-x is a numeric vector. These are the most common kind. They are numeric objects and are treated as double precision real numbers. To explicitly create integers, add a `L` at the end.
+`x` is a numeric vector. These are the most common kind. They are numeric objects and are treated as double precision real numbers. To explicitly create integers, add a `L` at the end.
 
 ```{r, eval = TRUE}
 x1 <- c(1L, 2L, 3L)
@@ -125,7 +124,6 @@ More examples of vectors
 ```{r, eval = TRUE}
 x <- c(0.5, 0.7)
 x <-c (TRUE, FALSE)
-x <- c(T, F)
 x <- c("a", "b", "c", "d", "e")
 x <- 9:100
 x <- c(1+0i, 2+4i)
@@ -211,7 +209,7 @@ as.character(x)
 as.complex(x) 
 ```
 
-Sometimes coercions, especially nonsensical ones won’t work.
+Sometimes coercions, especially nonsensical ones, won’t work.
 
 ```{r, eval = TRUE}
 x <- c("a", "b", "c")
@@ -230,7 +228,7 @@ as.logical(x)
 
 ## Matrix
 
-Matrices are a special vector in R. They are not a separate class of object but simply a vector but now with dimensions added on to it. Matrices have rows and columns. 
+Matrices are a special vector in R. They are not a separate type of object but simply an atomic vector with dimensions added on to it. Matrices have rows and columns. 
 
 ```{r, eval = TRUE}
 m <- matrix(nrow = 2, ncol = 2)
@@ -238,7 +236,7 @@ m
 dim(m)
 ```
 
-Matrices are constructed columnwise. 
+Matrices are filled column-wise. 
 
 ```{r, eval = TRUE}
 m <- matrix(1:6, nrow = 2, ncol = 3)
@@ -277,14 +275,13 @@ mdat
 
 ## List
 
-In R lists act as containers. Unlike atomic vectors, its contents are not restricted to a single mode and can encompass any data type. Lists are sometimes called recursive vectors, because a list can contain other lists. This makes them fundamentally different from atomic vectors. 
+In R lists act as containers. Unlike atomic vectors, the contents of a list are not restricted to a single mode and can encompass any mixture of data types. Lists are sometimes called recursive vectors, because a list can contain other lists. This makes them fundamentally different from atomic vectors. 
 
-List is a special vector. Each element can be a different class.
+List is a special vector. Each element can be a different type.
 
 
 
-Create lists using `list` or coerce other objects using `as.list()`
-
+Create lists using `list()` or coerce other objects using `as.list()`
 
 ```{r, eval = TRUE}
 x <- list(1, "a", TRUE, 1+4i)
@@ -308,7 +305,7 @@ xlist
 what is the length of this object?
 what about its structure?
 
-List can contain as many lists nested inside.
+A list can contain many lists nested inside.
 
 ```{r, eval = TRUE}
 temp <- list(list(list(list())))
@@ -322,7 +319,6 @@ It doesn't print out like a vector. Prints a new line for each element.
 
 Elements are indexed by double brackets. Single brackets will still return a(nother) list.
 
-
 ---
 
 ## Factors
@@ -333,19 +329,17 @@ Factors can only contain pre-defined values.
 
 Factors are pretty much integers that have labels on them.  While factors look (and often behave) like character vectors, they are actually integers under the hood, and you need to be careful when treating them like strings. Some string methods will coerce factors to strings, while others will throw an error.
 
-Sometimes factors can be left unordered. Example: male, female
+Sometimes factors can be left unordered. Example: `male`, `female`.
 
-Other times you might want factors to be ordered (or ranked). Example: low, medium, high. 
-
+Other times you might want factors to be ordered (or ranked). Example: `low`, `medium`, `high`. 
 
 Underlying it's represented by numbers 1, 2, 3.
 
+They are better than using simple integer labels because factors are what are called self describing. `male` and `female` is more descriptive than `1`s and `2`s. Helpful when there is no additional metadata.
 
-They are better than using simple integer labels because factors are what are called self describing. male and female is more descriptive than 1s and 2s. Helpful when there is no additional metadata.
+Which is `male`? `1` or `2`? You wouldn't be able to tell with just integer data. Factors have this information built in.
 
-Which is male? 1 or 2? You wouldn't be able to tell with just integer data. Factors have this information built in.
-
-Factors can be created with `factor()`. Input is a character vector.
+Factors can be created with `factor()`. Input is generally a character vector.
 
 ```
 x <- factor(c("yes", "no", "no", "yes", "yes"))
@@ -356,30 +350,26 @@ x
 
 `unclass(x)` strips out the class information.
 
-In modeling functions, importnat to know whta baseline levels is.
+In modeling functions, important to know what the baseline levels is.
 This is the first factor but by default the ordering is determined by alphabetical order of words entered. You can change this by speciying the levels.
 
 ```
 x <- factor(c("yes", "no", "yes"), levels = c("yes", "no"))
 ```
+
 ## Data frame
 
-A data frame is a very important data type in R. It's pretty much the de facto data structure for most tabular data and what we use for statistics.
+A data frame is a very important data type in R. It's pretty much the *de facto* data structure for most tabular data and what we use for statistics.
 
-data frames can have additional attributes such as `rownames()`. This can be useful for annotating data, like subject_id or sample_id. But most of the time they are not used.
+Data frames can have additional attributes such as `rownames()`, which can be useful for annotating data, like subject_id or sample_id. But most of the time they are not used.
 
-e.g. `rownames()`
-useful for annotating data. subject names.
-other times they are not useful.
-
-* Data frames Usually created by `read.csv` and `read.table`.
+* Data frames Usually created by `read.csv()` and `read.table()`.
 
 * Can convert to `matrix` with `data.matrix()`
 
-* Coercion will force and not always what you expect.
+* Coercion will be forced and not always what you expect.
 
 * Can also create with `data.frame()` function.
-
 
 With and data frame, you can do `nrow(df)` and `ncol(df)`
 rownames are usually 1..n.
@@ -396,15 +386,15 @@ cbind(df, data.frame(z = 4))
 When you combine column wise, only row numbers need to match. If you are adding a vector, it will get repeated.
 
 **Useful functions**  
-* `head()` - see first 5 rows
-* `tail()` - see last 5 rows
+* `head()` - see first 6 rows
+* `tail()` - see last 6 rows
 * `dim()` - see dimensions
 * `nrow()` - number of rows
 * `ncol()` - number of columns
 * `str()` - structure of each column
-* `names()` - will list column names for a data.frame (or any object really).
+* `names()` - will list the `names` attribute for a data frame (or any object really), which gives the column names.
 
-A data frame is a special type of list where every element of a list has same length.
+A data frame is a special type of list where every element of the list has same length.
 
 See that it is actually a special list:
 
@@ -412,12 +402,12 @@ See that it is actually a special list:
     [1] TRUE
     > class(iris)
     [1] "data.frame"
-     > 
+    > 
 --
 
-**Naming objects**  
+**Naming objects**
 
-Other R objects can also have names not just true for data.frames. Adding names is helpful since it's useful for readable code and self describing objects.
+Other R objects can also have names not just true for data frames. Adding names is helpful since it's useful for readable code and self describing objects.
 
 ```{r, eval = TRUE}
 x <- 1:3
@@ -442,6 +432,7 @@ dimnames(m) <- list(c("a", "b"), c("c", "d"))
 # second element = colnames
 m
 dimnames(m)
+colnames(m) ## or rownames(m)
 ```
 
 ---
@@ -449,7 +440,7 @@ dimnames(m)
 
 ## Missing values
 
-dennoted by `NA` and/or `NaN` for undefined mathematical operations.
+Denoted by `NA` and/or `NaN` for undefined mathematical operations.
 
 ```{r, eval = FALSE}
 is.na()
@@ -458,25 +449,27 @@ is.nan()
 
 check for both.
 
-NA values have a class. So you can have both an integer NA and a missing character NA.
+NA values have a class. So you can have both an integer NA (`NA_integer_`) and a character NA (`NA_character_`).
 
-Nan is also NA. But not the other way around.
+`NaN` is also `NA`. But not the other way around.
 
 ```{r, eval = TRUE}
 x <- c(1,2, NA, 4, 5)
 x
 ```
 
-`is.na(x)` returns logical.
-shows third
+```{r, eval = TRUE}
+is.na(x) # returns logical
+# shows third
 
-`is.nan(x)`
- # none are NaN.
+is.nan(x)
+# none are NaN
+```
 
 ```{r, eval = TRUE}
 x <- c(1,2, NA, NaN, 4, 5)
 is.na(x)
-#shows 2 TRUE.
+# shows 2 TRUE
 is.nan(x)
 # shows 1 TRUE
 ```

--- a/lessons/misc-r/full-R-bootcamp/R-basics/best-practices.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/best-practices.Rmd
@@ -4,7 +4,7 @@
 1. Manage all of your source files for a project in the same directory. Then use relative paths as necessary. For example, use
 
 ```{R, eval = FALSE}
-df <- read.csv(file = "/files/dataset-2013-01.csv", header = TRUE)
+df <- read.csv(file = "files/dataset-2013-01.csv", header = TRUE)
 ```
 
 rather than:
@@ -15,7 +15,7 @@ df <- read.csv(file = "/Users/Karthik/Documents/sannic-project/files/dataset-201
 
 2. Never change the working directory once a script is underway. Use `setwd()` first . Do it at the beginning of a R session. Better yet, start R inside a project folder.
 
-3. Don't save a session history (the default option in R). Instead, start in a clean environment so that older objects don't contaminate your current environment. This can lead to unexpected results, especially if the code were to be run on someone else's machine.
+3. Don't save a session on exit (the default option in R). Instead, start in a clean environment so that older objects don't contaminate your current environment. This can lead to unexpected results, especially if the code were to be run on someone else's machine.
 
 4. Where possible attach `sessionInfo()` somewhere in your project folder. Session information is invaluable since it captures all of the packages used in the current project. If a newer version of a project changes the way a function behaves, you can always go back and reinstall the version that worked (Note: At least on CRAN all older versions of packages are permanently archived).
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/exercise.md.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/exercise.md.Rmd
@@ -23,10 +23,10 @@ mtcars[mtcars$cyl == 4 | 6, ]
 3. Why does `mtcars[1:20]` return a error? How does it differ from the similar `mtcars[1:20, ]`?
 
 
-4. Load the `ggplot2` library. There should be a dataset called diamonds. You can verify that by typing in `data(diamonds)`
+4. Load the `ggplot2` package. There should be a dataset called `diamonds`. You can verify that by typing in `data(diamonds)`
 
 * How big is this dataset (number of rows and columns)?
-* Create a new `data.frame` called `small_diamonds` that only contains rows 1 through 9 and 19 through 23. You can do this in one or two steps.
+* Create a new data frame called `small_diamonds` that only contains rows 1 through 9 and 19 through 23. You can do this in one or two steps.
 
 5. Given a linear model
 
@@ -34,7 +34,7 @@ mtcars[mtcars$cyl == 4 | 6, ]
 mod <- lm(mpg ~ wt, data = mtcars)
 ```
 
-Extract the residual degrees of freedom. 
+extract the residual degrees of freedom.
 
 
 ----

--- a/lessons/misc-r/full-R-bootcamp/data-manipulation/00-messy_data.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/data-manipulation/00-messy_data.Rmd
@@ -15,18 +15,18 @@ Raw data from various ecological studies can be poorly formatted and/or may lack
 
 1. Values as columns  (melt to long format)
 2. Multiple values in a single cell (some regexpr to split em)
-3. variables in rows (cast)
+3. Variables in rows (cast)
 
 
 ### A warm-up example
 
 
 ```{r, eval = TRUE}
-dat = data.frame(males = c(injured = 4, uninjured = 2), females = c(injured = 1, uninjured = 5))
+dat <- data.frame(males = c(injured = 4, uninjured = 2), females = c(injured = 1, uninjured = 5))
 dat
 ```
 
-names as a column we can manipulate
+Rowames as a column we can manipulate
 
 ```{r, eval = TRUE}
 dat <- cbind(dat, status = rownames(dat)) 
@@ -36,7 +36,7 @@ dat
 Get values out of columns, variables as columns:
 
 ```{r , eval = TRUE}
-library(reshape2)
+library("reshape2")
 dat <- melt(dat, "status") 
 ```
 
@@ -55,7 +55,7 @@ names(dat) <- c("status", "sex", "count")
 In the example below, we use a data file obtained as plain text and clean up incorrect spacing, separators. Then we look up the appropriate metadata 
 
 ```{r, load_data}
-library(stringr)
+library("stringr")
 # If you don't have this package simply run install.packages("stringr")
 rawData <- readLines("../data/messy_data.txt")
 ```
@@ -69,7 +69,8 @@ We've got two issues here. First, we need to split the dates into two separate f
 
 
 ```{r clean_up}
-# First we use a function in the stringr package to locate where the dashes are. Note that we are not just searching for the dash but a string that includes the space before and after.
+# First we use a function in the stringr package to locate where the dashes are.
+# Note that we are not just searching for the dash but a string that includes the space before and after.
 dashes <- str_locate_all(rawData, " - ")
 # Let's make sure it looks right
 rawData[1]
@@ -77,7 +78,7 @@ dashes[1]
 ```
 
 ```{r functions}
-## -----------------------------------------------
+# -----------------------------------------------
 # A function to remove extra spaces and split the dates
 # -------------------------------------------
 splitByDate <- function(str, start, finish) {
@@ -89,33 +90,33 @@ splitByDate <- function(str, start, finish) {
     beginning <- str_trim(beginning)
     dates <- str_split(dates, " - ")
 
-      while(str_detect(end, "  ")) {
-    end <- str_replace_all(str_trim(end), "  ", " ")    
-  }
+    while(str_detect(end, "  ")) {
+       end <- str_replace_all(str_trim(end), "  ", " ")    
+    }
 
-  end <- str_split(end, " ")
+    end <- str_split(end, " ")
     return(c(unlist(beginning), unlist(dates), unlist(end)))
 }
 
 # A function to return a nicely formatted dataset
 # -------------------------------------------
 formatData  <- function(rawD) {
-longest_row <- max(sapply(rawD, length))
-# If any rows have missing data, we pad it with NAs so we get a clean data.frame
-results <- sapply(rawD, function(y) {
+    longest_row <- max(sapply(rawD, length))
+    # If any rows have missing data, we pad it with NAs so we get a clean data.frame
+    results <- sapply(rawD, function(y) {
         if(length(y) < longest_row)
             c(y, rep(NA, longest_row - length(y))) 
         else 
             y
     })
 
-return(as.data.frame(t(results)))
+    return(as.data.frame(t(results)))
 } 
 
 ```{r, clean_data}
 first_pass <- sapply(1:length(rawData), function(x) {
     splitByDate(rawData[x], dashes[[x]][1], dashes[[x]][2])
-    })
+})
 
 cleaned_data <- formatData(first_pass)
 names(cleaned_data) <- c("observer", "date_first", "date_last", "id", "distance", "direction", "speed", "measurex", "measurey", "migratory_status", "times_observed")
@@ -144,7 +145,7 @@ head(cleaned_data)
 tail(cleaned_data)
 ```
 
-Now we can confidently save these data into a separate file which w called `cleaned_data.csv`. In a real world use case your file name would be more descriptive.
+Now we can confidently save these data into a separate file which we called `cleaned_data.csv`. In a real world use case your file name would be more descriptive.
 
 
 ```{r save_data}

--- a/lessons/misc-r/full-R-bootcamp/functions/function_examples.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/functions/function_examples.Rmd
@@ -9,7 +9,7 @@ After a while operations at the interactive prompt are not enough. You have spec
 * Example
 
 Functions are created using the `function()` directive.
-They are stored as any other R object.  They are of class "function"
+They are stored as any other R object.  They are of class `"function"`.
 
 **Basic syntax**
 
@@ -21,7 +21,7 @@ func <- function(<take some input>)  {
 
 Functions are first class objects. Treat them the same way as any other objects. This means you can pass them to other functions (as you would do with say vectors). Very useful feature for statistical analyses. We can also nest functions inside each other.
 
-Return value is the very last R expression to be evaluated. No special expression for returning although you can use return()
+Return value is the very last R expression to be evaluated. To specify the return value, you can use `return()`, and you have to if you wish to return early. Note that it is marginally more efficient to use `foo` and not `return(foo)` as the last statement in the function to set `foo` as the return value.
 
 Functions have named arguments and these can have default values. Arguments used inside a function definition are called formal arguments.
 
@@ -29,7 +29,7 @@ use `formals()` to see what they are.
 
 Not every function makes use of all formal arguments.
 
-Function arguments can be missing or might just use default values. Formal arguments are included in the function definition.
+Function arguments can be missing or might just use default values. 
 
 If a function has 10 arguments, you don't have to specify all of them. 
 
@@ -40,7 +40,7 @@ args(sd)
 ```
 
 
-Takes x, a vector of data. 
+Takes `x`, a vector of data. 
 Default is `na.rm` is false.
 So you don't have to do anything.
 
@@ -77,7 +77,7 @@ a^2
 }
 ```
 
-The function call never uses b. So calling `f(10)` will not produce an error because `a` got positionally matched.
+The function call never uses `b`. So calling `f(10)` will not produce an error because `a` was matched positionally.
 
 Another example of lazy evaluation
 
@@ -89,9 +89,9 @@ print(b^2)
 }
 ```
 
-`add(10)` will work until it reaches a point where the function will break.
+`add(10)` will work until it reaches a point where the function will break as `b` is not defined.
 
-**The three dot operator.**
+**The dots operator.**
 
 `...` are used when extending another function and you don't want to copy the entire list of arguments from the original function.
 


### PR DESCRIPTION
The first argument to `install.packages()` is a library location, not a package. You can't update single packages with `update.packages()`, you can just install the package with `install.packages()`.

I also put the code example into a code block.

Changes in the second commit are mostly minor. Main change is to tweak how you refer to vectors and to simplify the way these are introduced, as in use `character()` not `vector("character")`. A number of other fixes/changes for nomenclature, consistency ect.
