### PR TITLE
tidy = FALSE to preserve code formatting

### DIFF
--- a/lessons/misc-r/full-R-bootcamp/R-basics/01-basics-of-R.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/01-basics-of-R.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 # Very basics of R
 
 R is a versatile, open source programming/scripting language that's useful both for statistics but also data science. Inspired by the programming language [`S`][S].

--- a/lessons/misc-r/full-R-bootcamp/R-basics/02-data-structures.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/02-data-structures.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Understanding basic data types in R
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/03-best-practices.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/03-best-practices.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Some best practices for using R
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/04-seeking-help.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/04-seeking-help.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Diagnostic functions in R
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/05-subsetting.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/05-subsetting.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Subsetting data
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/06-vectorization.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/06-vectorization.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 # Some notes on vectorization
 
 Many operations in R are vectorized which means that writing code is more efficient, concise and easy to read.

--- a/lessons/misc-r/full-R-bootcamp/R-basics/best-practices.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/best-practices.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
  
 # Some best practices for using R
 

--- a/lessons/misc-r/full-R-bootcamp/R-basics/rstudio-basics.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/R-basics/rstudio-basics.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Getting started with RStudio
 

--- a/lessons/misc-r/full-R-bootcamp/chunk_options.R
+++ b/lessons/misc-r/full-R-bootcamp/chunk_options.R
@@ -1,0 +1,2 @@
+library(knitr)
+opts_chunk$set(tidy = FALSE)

--- a/lessons/misc-r/full-R-bootcamp/data-manipulation/00-messy_data.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/data-manipulation/00-messy_data.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # A short tutorial on how to read and clean messy data
 

--- a/lessons/misc-r/full-R-bootcamp/data-manipulation/01-input-output.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/data-manipulation/01-input-output.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Input output operations
 

--- a/lessons/misc-r/full-R-bootcamp/data-manipulation/02-apply-family.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/data-manipulation/02-apply-family.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Learning the apply family of functions
 

--- a/lessons/misc-r/full-R-bootcamp/data-manipulation/03-split-apply.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/data-manipulation/03-split-apply.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Using the split-apply strategy to manipulate data
 

--- a/lessons/misc-r/full-R-bootcamp/functions/01-functions.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/functions/01-functions.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Writing functions in R
 

--- a/lessons/misc-r/full-R-bootcamp/functions/02-control_structures.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/functions/02-control_structures.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Control structures in R
 

--- a/lessons/misc-r/full-R-bootcamp/functions/03-scoping_rules.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/functions/03-scoping_rules.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 # Scoping in R
 
 Assuming we run the following code:

--- a/lessons/misc-r/full-R-bootcamp/functions/function_examples.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/functions/function_examples.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 # Functions 
 
 Represent one of the most powerful features of the R language. By creating functions, you can go past just using what others have written and create your own.

--- a/lessons/misc-r/full-R-bootcamp/testing-documentation/testing.Rmd
+++ b/lessons/misc-r/full-R-bootcamp/testing-documentation/testing.Rmd
@@ -1,3 +1,6 @@
+```{r, include = FALSE}
+source("../chunk_options.R")
+```
 
 # Software Testing
 


### PR DESCRIPTION
Created file to hold global chunk options. Specifically this is to set
the chunk option tidy to FALSE, which means code chunks will appear
exactly as written in the RMarkdown file. Each RMarkdown file sources
this file with the global chunk options making it easy to change the
behaviour of all the lessons at once. I added the chunk which sources
this file to all the RMarkdown files using the following command:

```
find full-R-bootcamp/ -name "*Rmd" -exec sed -i 1i'\`\`\`{r, include = FALSE}\nsource("../chunk_options.R")\n\`\`\`' {} \;
```
